### PR TITLE
Run dump-autoload for finding migration classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@ Example sprinkle for extending the User class to contain additional fields.
 
 # Installation
 
-Edit UserFrosting `app/sprinkles.json` and add the following to the `require` list : `"userfrosting/extend-user": "~4.1.1"`. Also add `extend-user` to the `base` list. For example:
+Edit UserFrosting `app/sprinkles.json` and add `extend-user` to the `base` list. For example:
 
 ```
 {
-    "require": {
-        "userfrosting/extend-user": "~4.1.1"
-    },
     "base": [
         "core",
         "account",
@@ -22,6 +19,7 @@ Edit UserFrosting `app/sprinkles.json` and add the following to the `require` li
 
 ### Update Composer
 
+- Run `composer dump-autoload` from the root project directory.
 - Run `composer update` from the root project directory.
 
 ### Run migration


### PR DESCRIPTION
Adding a require statement to the example package is less useful than updating the autoload classes for finding the migration class.